### PR TITLE
Updated production_root and production_non_root to point the ckan_license.json to correct location.

### DIFF
--- a/contrib/docker/production_non_root_url.ini
+++ b/contrib/docker/production_non_root_url.ini
@@ -207,7 +207,7 @@ ckan.display_timezone = UTC
 #ckan.recaptcha.privatekey =
 
 #license file downloaded from https://licenses.opendefinition.org/licenses/groups/ckan.json
-licenses_group_url = file:///usr/lib/ckan/venv/src/cioos-siooc-schema/ckan_license.json
+licenses_group_url = file:///usr/lib/ckan/venv/src/ckanext-scheming/ckanext/scheming/ckan_license.json
 
 # ckan.template_footer_end =
 

--- a/contrib/docker/production_root_url.ini
+++ b/contrib/docker/production_root_url.ini
@@ -213,7 +213,7 @@ ckan.display_timezone = UTC
 #ckan.recaptcha.privatekey =
 
 #license file downloaded from https://licenses.opendefinition.org/licenses/groups/ckan.json
-licenses_group_url = file:///usr/lib/ckan/venv/src/cioos-siooc-schema/ckan_license.json
+licenses_group_url = file:///usr/lib/ckan/venv/src/ckanext-scheming/ckanext/scheming/ckan_license.json
 
 # ckan.template_footer_end =
 


### PR DESCRIPTION
This will fix the fetch harvest crashing on a fresh ckan install once images are updated.