### PR TITLE
Rotate and reduce frequency of solr logs

### DIFF
--- a/contrib/docker/docker-compose.cpu_limited.yml
+++ b/contrib/docker/docker-compose.cpu_limited.yml
@@ -183,7 +183,7 @@ services:
 
   solr:
     container_name: solr
-    image: cioos/solr:latest
+    image: hakaiinstitute/solr:latest
     build:
       context: ../../
       dockerfile: contrib/docker/solr/Dockerfile

--- a/contrib/docker/docker-compose.cpu_limited.yml
+++ b/contrib/docker/docker-compose.cpu_limited.yml
@@ -190,8 +190,14 @@ services:
     restart: unless-stopped
     ports:
       - "8983:8983"
+    environment:
+      - SOLR_LOG_LEVEL=WARN
     volumes:
       - solr_data:/var/solr
+    logging:
+      options:
+        max-size: "100m"
+        max-file: "3"
     deploy:
       resources:
         limits:

--- a/contrib/docker/docker-compose.hakai.yml
+++ b/contrib/docker/docker-compose.hakai.yml
@@ -190,8 +190,14 @@ services:
     restart: unless-stopped
     ports:
       - "8983:8983"
+    environment:
+      - SOLR_LOG_LEVEL=WARN
     volumes:
       - solr_data:/var/solr
+    logging:
+      options:
+        max-size: "100m"
+        max-file: "3"
     deploy:
       resources:
         limits:

--- a/contrib/docker/docker-compose.local.yml
+++ b/contrib/docker/docker-compose.local.yml
@@ -136,8 +136,14 @@ services:
     build:
       context: ../../
       dockerfile: contrib/docker/solr/Dockerfile
+    environment:
+      - SOLR_LOG_LEVEL=WARN
     volumes:
       - solr_data:/var/solr
+    logging:
+      options:
+        max-size: "100m"
+        max-file: "3"
     #restart: always
 
   redis:

--- a/contrib/docker/docker-compose.local.yml
+++ b/contrib/docker/docker-compose.local.yml
@@ -132,7 +132,7 @@ services:
 
   solr:
     container_name: solr
-    image: cioos/solr:latest
+    image: hakaiinstitute/solr:latest
     build:
       context: ../../
       dockerfile: contrib/docker/solr/Dockerfile

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -166,6 +166,10 @@ services:
       - "8983:8983"
     volumes:
       - solr_data:/var/solr
+    logging:
+      options:
+        max-size: "100m"
+        max-file: "3"
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8983/solr/ckan/admin/ping?wt=json |  grep -iq '\"status\":\"OK\"' || exit 1"]
       start_period: 15s

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -157,10 +157,7 @@ services:
 
   solr:
     container_name: solr
-    image: cioos/solr:latest
-    build:
-      context: ../../
-      dockerfile: contrib/docker/solr/Dockerfile
+    image: hakaiinstitute/solr:latest
     restart: unless-stopped
     ports:
       - "8983:8983"

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -164,6 +164,8 @@ services:
     restart: unless-stopped
     ports:
       - "8983:8983"
+    environment:
+      - SOLR_LOG_LEVEL=WARN
     volumes:
       - solr_data:/var/solr
     logging:

--- a/contrib/docker/solr/Dockerfile
+++ b/contrib/docker/solr/Dockerfile
@@ -9,7 +9,7 @@ EXPOSE 8983
 ENV SOLR_CORE ckan
 ENV SOLR_CONFIG_DIR="/opt/solr/server/solr/configsets"
 ENV SOLR_SCHEMA_FILE="$SOLR_CONFIG_DIR/ckan/conf/managed-schema"
-ENV SOLR_LOG_LEVEL=WARN
+ENV SOLR_LOG_LEVEL=${SOLR_LOG_LEVEL:-WARN}
 
 USER root
 

--- a/contrib/docker/solr/Dockerfile
+++ b/contrib/docker/solr/Dockerfile
@@ -9,6 +9,7 @@ EXPOSE 8983
 ENV SOLR_CORE ckan
 ENV SOLR_CONFIG_DIR="/opt/solr/server/solr/configsets"
 ENV SOLR_SCHEMA_FILE="$SOLR_CONFIG_DIR/ckan/conf/managed-schema"
+ENV SOLR_LOG_LEVEL=WARN
 
 USER root
 


### PR DESCRIPTION
The Solr container was generating large logs files without rotation, filling up the /data filesystem.

This PR
- reduces the frequency of logging and `SOLR_LOG_LEVEL`
- Add Docker log rotation to Solr service to prevent disk space issues

To apply these changes we will at least need to:
```bash
sudo docker compose restart solr
```

This should prevent future disk space issues from runaway container logs _and_ maintain recent log history for debugging.